### PR TITLE
Have zstd remove uncompressed files after compression.

### DIFF
--- a/src/compressdoc
+++ b/src/compressdoc
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-VERSION=20211031
+VERSION=202211119
 
 # Setting CDPATH in the environment may cause issues
 unset CDPATH

--- a/src/compressdoc
+++ b/src/compressdoc
@@ -306,7 +306,7 @@ if [ "$FAKE" != "no" ]; then
     --lzip|--lz|-l) echo -n "lzip";;
     --lzma|--xz|-J) echo -n "xz";;
     --lzop) echo -n "lzop";;
-    --zstd) echo -n "zstd";;
+    --zstd) echo -n "zstd --rm";;
     --decompress|-d) echo -n "decompressing";;
     *) echo -n "unknown";;
   esac

--- a/src/compressdoc
+++ b/src/compressdoc
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-VERSION=202211119
+VERSION=20221119
 
 # Setting CDPATH in the environment may cause issues
 unset CDPATH

--- a/src/compressdoc
+++ b/src/compressdoc
@@ -306,7 +306,7 @@ if [ "$FAKE" != "no" ]; then
     --lzip|--lz|-l) echo -n "lzip";;
     --lzma|--xz|-J) echo -n "xz";;
     --lzop) echo -n "lzop";;
-    --zstd) echo -n "zstd --rm";;
+    --zstd) echo -n "zstd";;
     --decompress|-d) echo -n "decompressing";;
     *) echo -n "unknown";;
   esac
@@ -507,7 +507,7 @@ for DIR in $MAN_DIR; do
             echo "Compressed $FILE" > $DEST_FD1
             ;;
           *zst)
-            zstd ${COMP_LVL} "$FILE" && chmod 644 "${FILE}${COMP_SUF}"
+            zstd --rm ${COMP_LVL} "$FILE" && chmod 644 "${FILE}${COMP_SUF}"
             echo "Compressed $FILE" > $DEST_FD1
             ;;
           *)


### PR DESCRIPTION
The `zstd` option does not remove the uncompressed files. This leads to duplicate file issues from `mandb -c`.

This just adds the `--rm` option to zstd.